### PR TITLE
Allow for construction of `Reader` from any type `R: Read + Seek`

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -198,7 +198,8 @@ impl<R> Reader<R>
         {
             let is_wav = match hound::WavReader::new(&mut reader) {
                 Err(hound::Error::FormatError(_)) => false,
-                _ => true,
+                Err(err) => return Err(err.into()),
+                Ok(_) => true,
             };
             try!(reader.seek(std::io::SeekFrom::Start(0)));
             if is_wav {
@@ -210,7 +211,8 @@ impl<R> Reader<R>
         {
             let is_flac = match claxon::FlacReader::new(&mut reader) {
                 Err(claxon::Error::FormatError(_)) => false,
-                _ => true,
+                Err(err) => return Err(err.into()),
+                Ok(_) => true,
             };
             try!(reader.seek(std::io::SeekFrom::Start(0)));
             if is_flac {
@@ -223,7 +225,8 @@ impl<R> Reader<R>
             let is_ogg_vorbis = match lewton::inside_ogg::OggStreamReader::new(&mut reader) {
                 Err(lewton::VorbisError::OggError(_)) |
                 Err(lewton::VorbisError::BadHeader(lewton::header::HeaderReadError::NotVorbisHeader)) => false,
-                _ => true,
+                Err(err) => return Err(err.into()),
+                Ok(_) => true,
             };
             try!(reader.seek(std::io::SeekFrom::Start(0)));
             if is_ogg_vorbis {

--- a/src/read.rs
+++ b/src/read.rs
@@ -249,7 +249,7 @@ impl<R> Reader<R>
             };
             try!(reader.seek(std::io::SeekFrom::Start(0)));
             match maybe_err {
-                Some(err) => reader_errors.push(Box::new(err)),
+                Some(err) => reader_errors.push(Box::new(err) as Box<std::error::Error>),
                 None => return Ok(Reader::Flac(try!(claxon::FlacReader::new(reader)))),
             }
         }
@@ -262,7 +262,7 @@ impl<R> Reader<R>
             };
             try!(reader.seek(std::io::SeekFrom::Start(0)));
             match maybe_err {
-                Some(err) => reader_errors.push(Box::new(err)),
+                Some(err) => reader_errors.push(Box::new(err) as Box<std::error::Error>),
                 None => return Ok(Reader::OggVorbis(try!(lewton::inside_ogg::OggStreamReader::new(reader)))),
             }
         }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -7,6 +7,25 @@ const OGG_VORBIS: &'static str = "samples/sine_440hz_stereo.ogg";
 const WAV: &'static str = "samples/sine_440hz_stereo.wav";
 
 #[test]
+fn read() {
+    let flac = std::io::BufReader::new(std::fs::File::open(FLAC).unwrap());
+    match audio::Reader::new(flac).unwrap() {
+        audio::Reader::Flac(_) => (),
+        _ => panic!("Incorrect audio format"),
+    }
+    let wav = std::io::BufReader::new(std::fs::File::open(WAV).unwrap());
+    match audio::Reader::new(wav).unwrap() {
+        audio::Reader::Wav(_) => (),
+        _ => panic!("Incorrect audio format"),
+    }
+    let ogg_vorbis = std::io::BufReader::new(std::fs::File::open(OGG_VORBIS).unwrap());
+    match audio::Reader::new(ogg_vorbis).unwrap() {
+        audio::Reader::OggVorbis(_) => (),
+        _ => panic!("Incorrect audio format"),
+    }
+}
+
+#[test]
 fn open() {
     match audio::open(FLAC).unwrap() {
         audio::Reader::Flac(_) => (),
@@ -23,8 +42,8 @@ fn open() {
 }
 
 #[test]
-fn read_samples() {
-    fn read_all_samples<P>(path: P) -> usize
+fn open_and_read_samples() {
+    fn read_samples<P>(path: P) -> usize
         where P: AsRef<std::path::Path>,
     {
         let mut reader = audio::open(path).unwrap();
@@ -32,9 +51,9 @@ fn read_samples() {
     }
 
     // The original sample.
-    let num_wav_samples = read_all_samples(WAV);
+    let num_wav_samples = read_samples(WAV);
     // FLAC should be lossless.
-    assert_eq!(num_wav_samples, read_all_samples(FLAC));
+    assert_eq!(num_wav_samples, read_samples(FLAC));
     // Ogg Vorbis is lossy.
-    read_all_samples(OGG_VORBIS);
+    read_samples(OGG_VORBIS);
 }


### PR DESCRIPTION
This is a follow up to @est31's suggestion in #1 and is a follow on from
an earlier attempt at something similar I tried when first starting the
project.

The method attempts to detect the correct variant by attempting to
construct each of the format-specific readers and return the first one
that does not produce an error upon construction.

This feels a little hackish in that we depend on the upstream readers'
to first "confirm" the format and early return an `Err` (rather than
`panic!`ing or returning `Ok` anyway) if incorrect. Perhaps this is a
reasonable expectation though?

Also, this method requires that the successfully detected inner format
reader is constructed *twice*:

1. By passing the reader argument via `&mut` to test for the format. We
must use `&mut` to avoid moving the reader argument into the format
reader's constructor, otherwise we would not be able to re-use the
reader argument when testing the following formats.
2. Passing the reader argument via move for constructing the `Reader`
that will be returned after successfully detecting the format.

Perhaps a better/"proper" solution would be to dig a little deeper into
each of the upstream crates in order to find functionality specifically
suited to reading/confirming the header of each format? Or maybe it is
safe to assume that this would be the first step of the format reader
constructors anyway?

@est31 would be great to get your thoughts on all this!