### PR TITLE
Bump lewton version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [dependencies]
 claxon = { optional = true, version = "0.4" }
 hound = { optional = true, version = "3" }
-lewton = { optional = true, version = "0.9" }
+lewton = { optional = true, version = "0.10" }
 caf = { optional = true, version = "0.1" }
 alac = { optional = true, version = "0.5" }
 dasp_sample = "0.11.0"


### PR DESCRIPTION
lewton 0.9 used to have crate-type = [.., "cdylib"]

For whatever reason it made Cargo recompile it all the time during android build. 
It looks like a simple version bump fixes the problem!